### PR TITLE
Fix detection of "unknown-version" to allow ANSI escapes after whitespace

### DIFF
--- a/paruz
+++ b/paruz
@@ -53,7 +53,7 @@ __fzf_preview() {
 }
 
 __paruz_list() {
-  $PARUZ --color=always -Sl | sed -e 's: :/:; s/ unknown-version//'
+  $PARUZ --color=always -Sl | sed -E 's: :/:; s/ (\x1b\[[0-9;]*m)?unknown-version/\1/'
 }
 
 # main


### PR DESCRIPTION
Later versions of paru (unreleased just on master atm) have changed the output of `paru --color=always -Sl` to include ANSI escapes after whitespace. This did not work with the regular expression that's used to suppress "unknown-version" from appearing in the output of `_paru_list`.